### PR TITLE
Makes the player keyboard accessible.

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -15,16 +15,18 @@
 	</head>
 	<body>
 		<div id='title'></div>
-		<div id='sidebar'>
-			<h1>Terms</h1>
-			<div id='terms'></div>
-			<div id='checkbtn'>Done</div>
-		</div>
-		<div id="board">
+		<div id="board"
+			class='main-element'
+			tabindex='0'>
 			<canvas id='canvas' width=620 height=550></canvas>
 		</div>
+		<div id='sidebar' class='main-element'>
+			<h1>Terms</h1>
+			<div id='terms'></div>
+			<div id='checkbtn' tabindex='0'>Done</div>
+		</div>
 		<div id='backgroundcover' class='fade'></div>
-		<div id='alertbox' class='fade'>
+		<div id='alertbox' class='fade' inert='true'>
 			<div id='alertcaption'>Are you ready to submit your score?</div>
 			<input id='cancelbtn' class='cancel button' type='button' value='Not yet.'>
 			<input id='okbtn' class='submit button' type='button' value='Yep!'>
@@ -52,4 +54,3 @@
 		</script>
 	</body>
 </html>
-

--- a/src/player.scss
+++ b/src/player.scss
@@ -10,6 +10,11 @@ body {
 	font-family: 'Ruda', arial;
 	overflow: hidden;
 	cursor: default;
+
+	.main-element:focus {
+		outline: 2px solid $green;
+		outline-offset: -2px;
+	}
 }
 
 #title {
@@ -25,6 +30,19 @@ body {
 	font-weight: bold;
 	color: #fff;
 	background: #3498DB;
+}
+
+#board {
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	right: 180px;
+	top: 65px;
+
+	#canvas {
+		margin: 0;
+		padding: 0;
+	}
 }
 
 #sidebar {
@@ -72,11 +90,6 @@ body {
 			color: #000;
 		}
 	}
-}
-
-#canvas {
-	margin-top: 65px;
-	margin-left: 0px;
 }
 
 #backgroundcover {
@@ -177,4 +190,3 @@ body {
 		}
 	}
 }
-

--- a/src/puzzle.coffee
+++ b/src/puzzle.coffee
@@ -196,6 +196,34 @@ Namespace('WordSearch').Puzzle = do ->
 
 	getFinalWordPositionsString = -> finalWordPositions.trim(',')
 
+	# figure out roughly which letter the keyboard cursor is over based on X/Y
+	# position then pass roughly equivalent mouse coordinates to the usual _drawBoard
+	_drawBoardFromKeyboardEvent = (context, qset, selectStart, selectEnd, isSelecting) ->
+		console.log('drawing board from a keyboard event')
+		yOffset = HEADER_HEIGHT + PADDING_TOP
+		xOffset = PADDING_LEFT
+
+		startX = selectStart.x * _letterWidth + xOffset + _letterWidth / 2
+		startY = selectStart.y * _letterHeight + yOffset + _letterHeight / 2
+
+		endX = selectEnd.x * _letterWidth + xOffset + _letterWidth / 2
+		endY = selectEnd.y * _letterHeight + yOffset + _letterHeight / 2
+
+		calculatedMouseStart = x: startX, y: startY
+		calculatedMouseEnd = x: endX, y: endY
+
+		_drawBoard(context, qset,calculatedMouseStart, calculatedMouseEnd, isSelecting)
+
+		# draw a marker to indicate where the cursor is, after drawing the circled letters
+		if isSelecting
+			_context.moveTo(endX, endY - HEADER_HEIGHT)
+			_context.beginPath()
+			_context.arc(endX, endY - HEADER_HEIGHT, 5, 0, 2 * Math.PI, false)
+			_context.lineWidth = 2
+			_context.stroke()
+			_context.fillStyle = 'rgba(46,176,106,.5)'
+			_context.fill()
+
 	# clears and draws letters and ellipses on the canvas
 	_drawBoard = (context, qset, _clickStart, _clickEnd, _isMouseDown = false) ->
 		_qset = qset
@@ -439,4 +467,4 @@ Namespace('WordSearch').Puzzle = do ->
 	correctDiagonalVector: _correctDiagonalVector
 	addFoundWordCoordinates: _addFoundWordCoordinates
 	resetFoundWordCoordinates: _resetFoundWordCoordinates
-
+	drawBoardFromKeyboardEvent: _drawBoardFromKeyboardEvent

--- a/src/puzzle.coffee
+++ b/src/puzzle.coffee
@@ -199,7 +199,6 @@ Namespace('WordSearch').Puzzle = do ->
 	# figure out roughly which letter the keyboard cursor is over based on X/Y
 	# position then pass roughly equivalent mouse coordinates to the usual _drawBoard
 	_drawBoardFromKeyboardEvent = (context, qset, selectStart, selectEnd, isSelecting) ->
-		console.log('drawing board from a keyboard event')
 		yOffset = HEADER_HEIGHT + PADDING_TOP
 		xOffset = PADDING_LEFT
 
@@ -218,11 +217,11 @@ Namespace('WordSearch').Puzzle = do ->
 		if isSelecting
 			_context.moveTo(endX, endY - HEADER_HEIGHT)
 			_context.beginPath()
-			_context.arc(endX, endY - HEADER_HEIGHT, 5, 0, 2 * Math.PI, false)
-			_context.lineWidth = 2
+			_context.setLineDash([6, 5])
+			_context.arc(endX, endY - HEADER_HEIGHT, _letterHeight / 2, 0, 2 * Math.PI, false)
+			_context.lineWidth = 4
 			_context.stroke()
-			_context.fillStyle = 'rgba(46,176,106,.5)'
-			_context.fill()
+			_context.setLineDash([])
 
 	# clears and draws letters and ellipses on the canvas
 	_drawBoard = (context, qset, _clickStart, _clickEnd, _isMouseDown = false) ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,7 +4328,7 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 


### PR DESCRIPTION
Closes #27.

Rearranged elements in DOM and added tab indices to better control tab order.

Added logic to toggle inert on and off for certain elements on the page depending on whether the submission confirmation dialog is visible.

Made it possible to interact with the letter grid via keyboard.

Added logic to draw a separate dotted circle to indicate where they keyboard's 'cursor' is currently located while in the process of selecting a word.